### PR TITLE
Add a settings page to allow someone with manage_options permission to define static content URIs

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -29,7 +29,7 @@ class WellKnownPlugin {
    * @return array
    */
   public static function query_vars($vars) {
-    $vars[] = (new WellKnownConstants())->query_var;
+    $vars[] = QUERY_VAR;
 
     return $vars;
   }

--- a/plugin.php
+++ b/plugin.php
@@ -13,6 +13,16 @@ Author URI: http://notizblog.org/
  *
  * @author Matthias Pfefferle
  */
+class WellKnownConstants {
+  public $query_var = 'well-known';
+
+  public $option_name = 'well_known_option_name';
+
+  public $suffix_prefix = 'suffix_';
+  public $contents_prefix = 'contents_';
+}
+
+
 class WellKnownPlugin {
   /**
    * Add 'well-known' as a valid query variables.
@@ -21,7 +31,7 @@ class WellKnownPlugin {
    * @return array
    */
   public static function query_vars($vars) {
-    $vars[] = 'well-known';
+    $vars[] = (new WellKnownConstants())->query_var;
 
     return $vars;
   }
@@ -32,8 +42,9 @@ class WellKnownPlugin {
    * @param WP_Rewrite $wp_rewrite
    */
   public static function rewrite_rules($wp_rewrite) {
+    $c = new WellKnownConstants();
     $well_known_rules = array(
-      '.well-known/(.+)' => 'index.php?well-known='.$wp_rewrite->preg_index(1),
+      '.well-known/(.+)' => 'index.php?' . $c->query_var . '=' . $wp_rewrite->preg_index(1),
     );
 
     $wp_rewrite->rules = $well_known_rules + $wp_rewrite->rules;
@@ -45,8 +56,10 @@ class WellKnownPlugin {
    * @param WP $wp
    */
   public static function delegate_request($wp) {
-    if (array_key_exists('well-known', $wp->query_vars)) {
-      $id = $wp->query_vars['well-known'];
+    $c = new WellKnownConstants();
+
+    if (array_key_exists($c->query_var, $wp->query_vars)) {
+      $id = $wp->query_vars[$c->query_var];
 
       // run the more specific hook first
       do_action("well_known_{$id}", $wp->query_vars);
@@ -63,11 +76,16 @@ register_activation_hook(__FILE__, 'flush_rewrite_rules');
 register_deactivation_hook(__FILE__, 'flush_rewrite_rules');
 
 function well_known($query) {
-  $options = get_option('well_known_option_name');
+  $c = new WellKnownConstants();
+
+  $options = get_option($c->option_name);
   if (is_array($options)) {
-    well_knowing($query, $options['suffix_1'], $options['contents_1']);
-    well_knowing($query, $options['suffix_2'], $options['contents_2']);
-    well_knowing($query, $options['suffix_3'], $options['contents_3']);
+    foreach($options as $key => $value) {
+      if (strstr($key, $c->suffix_prefix) === FALSE) continue;
+
+      $offset = substr($key, strlen($c->suffix_prefix) - strlen($key));
+      well_knowing($query, $options, $offset);
+    }
   }
 
   status_header(404);
@@ -78,23 +96,25 @@ function well_known($query) {
 }
 add_action('well-known', 'well_known');
 
-function well_knowing($query, $suffix, $contents) {
-  if ((empty($suffix)) || (strstr($query['well-known'], $suffix) === false)) return;
+function well_knowing($query, $options, $offset) {
+  $c = new WellKnownConstants();
+
+  $suffix = $options[$c->suffix_prefix . $offset];
+  if ((empty($suffix)) || (strstr($query[$c->query_var], $suffix) === false)) return;
 
   header('Content-Type: text/plain; charset=' . get_option('blog_charset'), true);
+  $contents = $options[$c->contents_prefix . $offset];
   if (is_string($contents)) echo($contents);
 
   exit;
 }
 
-// adapted from Example #2 in https://codex.wordpress.org/Creating_Options_Pages
+
+// (mostly) adapted from Example #2 in https://codex.wordpress.org/Creating_Options_Pages
 class WellKnownSettings {
   private $options;
   private $slug = 'well-known-admin';
   private $option_group = 'well_known_option_group';
-  private $option_name = 'well_known_option_name';
-  private $suffix_id = 'suffix';
-  private $contents_id = 'contents';
 
   public function __construct() {
     add_action('admin_menu', array($this, 'add_plugin_page'));
@@ -111,7 +131,9 @@ class WellKnownSettings {
   }
 
   public function create_admin_page() {
-    $this->options = get_option($this->option_name);
+    $c = new WellKnownConstants();
+
+    $this->options = get_option($c->option_name);
 ?>
     <div class="wrap">
       <h1>Well-Known URIs</h1>
@@ -127,45 +149,63 @@ class WellKnownSettings {
     }
 
   public function page_init() {
-    $section_id = 'well_known_uri';
+    $c = new WellKnownConstants();
+
+    $section_prefix = 'well_known_uri';
     $suffix_title = 'Path: /.well-known/';
-    $contents_title = 'Textual contents:';
+    $contents_title = 'URI contents:';
 
-    register_setting($this->option_group, $this->option_name, array($this, 'sanitize_field'));
+    register_setting($this->option_group, $c->option_name, array($this, 'sanitize_field'));
 
-    add_settings_section($section_id . '_1', 'URI #1', array($this, 'print_section_info'), $this->slug);
-    add_settings_field($this->suffix_id . '_1', $suffix_title, array($this, 'field_callback'), $this->slug,
-		       $section_id . '_1', array('id' => $this->suffix_id . '_1', 'type' => 'text'));
-    add_settings_field($this->contents_id . '_1', $contents_title, array($this, 'field_callback'), $this->slug,
-		       $section_id . '_1', array('id' => $this->contents_id . '_1', 'type' => 'textarea'));
+    $options = get_option($c->option_name);
+    if (!is_array($options)) $j = 1;
+    else {
+      $newopts = array();
+      for ($i = 1, $j = 1;; $i++) {
+	if (!isset($options[$c->suffix_prefix . $i])) break;
+	if (empty($options[$c->suffix_prefix . $i])) continue;
 
-    add_settings_section($section_id . '_2', 'URI #2', array($this, 'print_section_info'), $this->slug);
-    add_settings_field($this->suffix_id . '_2', $suffix_title, array($this, 'field_callback'), $this->slug,
-		       $section_id . '_2', array('id' => $this->suffix_id . '_2', 'type' => 'text'));
-    add_settings_field($this->contents_id . '_2', $contents_title, array($this, 'field_callback'), $this->slug,
-		       $section_id . '_2', array('id' => $this->contents_id . '_2', 'type' => 'textarea'));
+/* courtesy of https://stackoverflow.com/questions/619610/whats-the-most-efficient-test-of-whether-a-php-string-ends-with-another-string#2137556 */
+        $reversed_needle = strrev('_' . $i);
+	foreach($options as $key => $value) {
+	  if (stripos(strrev($key), $reversed_needle) !== 0) continue;
 
-    add_settings_section($section_id . '_3', 'URI #3', array($this, 'print_section_info'), $this->slug);
-    add_settings_field($this->suffix_id . '_3', $suffix_title, array($this, 'field_callback'), $this->slug,
-		       $section_id . '_3', array('id' => $this->suffix_id . '_3', 'type' => 'text'));
-    add_settings_field($this->contents_id . '_3', $contents_title, array($this, 'field_callback'), $this->slug,
-		       $section_id . '_3', array('id' => $this->contents_id . '_3', 'type' => 'textarea'));
+	  $newopts[substr($key, 0, 1 + strlen($key) - strlen($reversed_needle)) . $j] = $value;
+	}
+        $j++;
+      }
+      error_log('old: ' . print_r($options, true));
+      error_log('new: ' . print_r($newopts, true));
+      update_option($c->option_name, $newopts);
+
+      for ($j = 1;; $j++) if (!isset($newopts[$c->suffix_prefix . $j])) break;
+    }
+
+    for ($i = 1; $i <= $j; $i++) {
+      add_settings_section($section_prefix . $i, 'URI #' . $i, array($this, 'print_section_info'), $this->slug);
+      add_settings_field($c->suffix_prefix . $i, $suffix_title, array($this, 'field_callback'), $this->slug,
+			 $section_prefix . $i, array('id' => $c->suffix_prefix . $i, 'type' => 'text'));
+      add_settings_field($c->contents_prefix . $i, $contents_title, array($this, 'field_callback'), $this->slug,
+			 $section_prefix . $i, array('id' => $c->contents_prefix . $i, 'type' => 'textarea'));
+    }
   }
 
-  public function print_section_info() { }
+  public function print_section_info() {}
 
   public function field_callback($params) {
+    $c = new WellKnownConstants();
+
     $id = $params['id'];
     $type = $params['type'];
     $value = '';
 
-    $prefix = '<input type="' . $type . '" id="' . $id . '" name="' . $this->option_name . '[' . $id . ']" ';
-    if ($type == 'text') {
+    $prefix = '<input type="' . $type . '" id="' . $id . '" name="' . $c->option_name . '[' . $id . ']" ';
+    if ($type === 'text') {
       $prefix .= 'size="80" value="';
       if (isset($this->options[$id])) $value = esc_attr($this->options[$id]);
       $suffix =  '" />';
-    } elseif ($type == 'textarea') {
-      $prefix = '<textarea id="' . $id . '" name="' . $this->option_name . '[' . $id . ']" rows="4" cols="80">';
+    } elseif ($type === 'textarea') {
+      $prefix = '<textarea id="' . $id . '" name="' . $c->option_name . '[' . $id . ']" rows="4" cols="80">';
       if (isset($this->options[$id])) $value = esc_textarea($this->options[$id]);
       $suffix = '</textarea>';
     }
@@ -173,14 +213,17 @@ class WellKnownSettings {
   }
 
   public function sanitize_field($input) {
+    $c = new WellKnownConstants();
+
     $valid = array();
 
-    $valid += $this->sanitize_suffix($input, $this->suffix_id . '_1');
-    $valid += $this->sanitize_suffix($input, $this->suffix_id . '_2');
-    $valid += $this->sanitize_suffix($input, $this->suffix_id . '_3');
-    $valid += $this->sanitize_contents($input, $this->contents_id . '_1');
-    $valid += $this->sanitize_contents($input, $this->contents_id . '_2');
-    $valid += $this->sanitize_contents($input, $this->contents_id . '_3');
+    for ($i = 1;; $i++) {
+      if (!isset($input[$c->suffix_prefix . $i])) break;
+
+      $valid += $this->sanitize_suffix($input, $c->suffix_prefix . $i);
+      $valid += $this->sanitize_contents($input, $c->contents_prefix . $i);
+    }
+    error_log('sanitize: ' . print_r($valid, true));
 
     return $valid;
   }

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
 Plugin Name: /.well-known/
 Plugin URI: http://wordpress.org/extend/plugins/well-known/
 Description: This plugin enables "Well-Known URIs" support for WordPress (RFC 5785: http://tools.ietf.org/html/rfc5785).
-Version: 1.0.1
+Version: 1.0.2
 Author: pfefferle
 Author URI: http://notizblog.org/
 */
@@ -14,7 +14,6 @@ Author URI: http://notizblog.org/
  * @author Matthias Pfefferle
  */
 class WellKnownPlugin {
-
   /**
    * Add 'well-known' as a valid query variables.
    *
@@ -49,8 +48,9 @@ class WellKnownPlugin {
     if (array_key_exists('well-known', $wp->query_vars)) {
       $id = $wp->query_vars['well-known'];
 
-      do_action("well-known", $wp->query_vars);
+      // run the more specific hook first
       do_action("well_known_{$id}", $wp->query_vars);
+      do_action("well-known", $wp->query_vars);
     }
   }
 }
@@ -61,3 +61,145 @@ add_action('generate_rewrite_rules', array('WellKnownPlugin', 'rewrite_rules'), 
 
 register_activation_hook(__FILE__, 'flush_rewrite_rules');
 register_deactivation_hook(__FILE__, 'flush_rewrite_rules');
+
+function well_known($query) {
+  $options = get_option('well_known_option_name');
+  if (is_array($options)) {
+    well_knowing($query, $options['suffix_1'], $options['contents_1']);
+    well_knowing($query, $options['suffix_2'], $options['contents_2']);
+    well_knowing($query, $options['suffix_3'], $options['contents_3']);
+  }
+
+  status_header(404);
+  header('Content-Type: text/plain; charset=' . get_option('blog_charset'), true);
+  echo 'Not ' . (is_array($options) ? 'Found' : 'configured');
+
+  exit;
+}
+add_action('well-known', 'well_known');
+
+function well_knowing($query, $suffix, $contents) {
+  if ((empty($suffix)) || (strstr($query['well-known'], $suffix) === false)) return;
+
+  header('Content-Type: text/plain; charset=' . get_option('blog_charset'), true);
+  if (is_string($contents)) echo($contents);
+
+  exit;
+}
+
+// adapted from Example #2 in https://codex.wordpress.org/Creating_Options_Pages
+class WellKnownSettings {
+  private $options;
+  private $slug = 'well-known-admin';
+  private $option_group = 'well_known_option_group';
+  private $option_name = 'well_known_option_name';
+  private $suffix_id = 'suffix';
+  private $contents_id = 'contents';
+
+  public function __construct() {
+    add_action('admin_menu', array($this, 'add_plugin_page'));
+    add_action('admin_notices', array($this, 'admin_notices'));
+    add_action('admin_init', array($this, 'page_init'));
+  }
+
+  public function add_plugin_page() {
+    add_options_page('Settings Admin', 'Well-Known URIs', 'manage_options', $this->slug, array($this, 'create_admin_page'));
+  }
+
+  public function admin_notices() {
+   settings_errors($this->option_group);
+  }
+
+  public function create_admin_page() {
+    $this->options = get_option($this->option_name);
+?>
+    <div class="wrap">
+      <h1>Well-Known URIs</h1>
+        <form method="post" action="options.php">
+<?php
+    settings_fields($this->option_group);
+    do_settings_sections($this->slug);
+    submit_button();
+?>
+        </form>
+    </div>
+<?php
+    }
+
+  public function page_init() {
+    $section_id = 'well_known_uri';
+    $suffix_title = '/.well-known/';
+    $contents_title = 'Text file contents:';
+
+    register_setting($this->option_group, $this->option_name, array($this, 'sanitize_field'));
+
+    add_settings_section($section_id . '_1', 'URI #1', array($this, 'print_section_info'), $this->slug);
+    add_settings_field($this->suffix_id . '_1', $suffix_title, array($this, 'field_callback'), $this->slug,
+		       $section_id . '_1', array('id' => $this->suffix_id . '_1', 'type' => 'text'));
+    add_settings_field($this->contents_id . '_1', $contents_title, array($this, 'field_callback'), $this->slug,
+		       $section_id . '_1', array('id' => $this->contents_id . '_1', 'type' => 'textarea'));
+
+    add_settings_section($section_id . '_2', 'URI #2', array($this, 'print_section_info'), $this->slug);
+    add_settings_field($this->suffix_id . '_2', $suffix_title, array($this, 'field_callback'), $this->slug,
+		       $section_id . '_2', array('id' => $this->suffix_id . '_2', 'type' => 'text'));
+    add_settings_field($this->contents_id . '_2', $contents_title, array($this, 'field_callback'), $this->slug,
+		       $section_id . '_2', array('id' => $this->contents_id . '_2', 'type' => 'textarea'));
+
+    add_settings_section($section_id . '_3', 'URI #3', array($this, 'print_section_info'), $this->slug);
+    add_settings_field($this->suffix_id . '_3', $suffix_title, array($this, 'field_callback'), $this->slug,
+		       $section_id . '_3', array('id' => $this->suffix_id . '_3', 'type' => 'text'));
+    add_settings_field($this->contents_id . '_3', $contents_title, array($this, 'field_callback'), $this->slug,
+		       $section_id . '_3', array('id' => $this->contents_id . '_3', 'type' => 'textarea'));
+  }
+
+  public function print_section_info() { }
+
+  public function field_callback($params) {
+    $id = $params['id'];
+    $type = $params['type'];
+    $value = isset($this->options[$id]) ? esc_attr($this->options[$id]) : '';
+
+    $prefix = '<input type="' . $type . '" id="' . $id . '" name="' . $this->option_name . '[' . $id . ']" ';
+    if ($type == 'text') {
+      $prefix .= 'size="80" value="';
+      $suffix =  '" />';
+    } elseif ($type == 'textarea') {
+      $prefix = '<textarea id="' . $id . '" name="' . $this->option_name . '[' . $id . ']" rows="4" cols="80">';
+      $suffix = '</textarea>';
+    }
+    echo($prefix . $value . $suffix);
+  }
+
+  public function sanitize_field($input) {
+    $valid = array();
+
+    $valid += $this->sanitize_suffix($input, $this->suffix_id . '_1');
+    $valid += $this->sanitize_suffix($input, $this->suffix_id . '_2');
+    $valid += $this->sanitize_suffix($input, $this->suffix_id . '_3');
+    $valid += $this->sanitize_contents($input, $this->contents_id . '_1');
+    $valid += $this->sanitize_contents($input, $this->contents_id . '_2');
+    $valid += $this->sanitize_contents($input, $this->contents_id . '_3');
+
+    return $valid;
+  }
+  public function sanitize_suffix($input, $id) {
+    $valid = array();
+
+    if (isset($input[$id])) {
+      $valid[$id] = trim(sanitize_text_field($input[$id]), '/');
+      if (strstr($valid[$id], '/') !== FALSE) {
+	add_settings_error($id, 'invalid_suffix', __('URI path must not contain "/"'), 'error');
+      }
+    }
+    return $valid;
+  }
+  public function sanitize_contents($input, $id) {
+    $valid = array();
+
+    if (isset($input[$id])) $valid[$id] = sanitize_text_field($input[$id]);
+    return $valid;
+  }
+}
+
+if (is_admin()) new WellKnownSettings();
+?>

--- a/plugin.php
+++ b/plugin.php
@@ -128,8 +128,8 @@ class WellKnownSettings {
 
   public function page_init() {
     $section_id = 'well_known_uri';
-    $suffix_title = '/.well-known/';
-    $contents_title = 'Text file contents:';
+    $suffix_title = 'Path: /.well-known/';
+    $contents_title = 'Textual contents:';
 
     register_setting($this->option_group, $this->option_name, array($this, 'sanitize_field'));
 
@@ -157,14 +157,16 @@ class WellKnownSettings {
   public function field_callback($params) {
     $id = $params['id'];
     $type = $params['type'];
-    $value = isset($this->options[$id]) ? esc_attr($this->options[$id]) : '';
+    $value = '';
 
     $prefix = '<input type="' . $type . '" id="' . $id . '" name="' . $this->option_name . '[' . $id . ']" ';
     if ($type == 'text') {
       $prefix .= 'size="80" value="';
+      if (isset($this->options[$id])) $value = esc_attr($this->options[$id]);
       $suffix =  '" />';
     } elseif ($type == 'textarea') {
       $prefix = '<textarea id="' . $id . '" name="' . $this->option_name . '[' . $id . ']" rows="4" cols="80">';
+      if (isset($this->options[$id])) $value = esc_textarea($this->options[$id]);
       $suffix = '</textarea>';
     }
     echo($prefix . $value . $suffix);
@@ -196,7 +198,8 @@ class WellKnownSettings {
   public function sanitize_contents($input, $id) {
     $valid = array();
 
-    if (isset($input[$id])) $valid[$id] = sanitize_text_field($input[$id]);
+    $valid[$id] = $input[$id];
+    if (isset($input[$id])) $valid[$id] = wp_filter_post_kses($input[$id]);
     return $valid;
   }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -45,41 +45,9 @@ page for this plugin.
     
 == Changelog ==
 
-= 0.6.2 =
+= 1.0.2 =
 
-* bug fix
-
-= 0.6.0 =
-
-* refactored the code
-
-= 0.5.1 =
-
-* fixed some php-warnings
-
-= 0.5 =
-
-* better action/filter
-
-= 0.4 =
-
-* some improvements for host-meta (jrd)
-
-= 0.3 =
-
-* adding well-known uris a bit more wordpress-like
-
-= 0.2.1.1 =
-
-* Ooops, copy&paste bug
-
-= 0.2.1 =
-
-* Forgot to flush the rewrite rules
-
-= 0.2 =
-
-* Better doku
+* Add Settings page to allow simple configuration of upto 3 textual URIs
 
 = 0.1 =
 
@@ -89,30 +57,40 @@ page for this plugin.
 
 1. Upload the `well-known`-folder to the `/wp-content/plugins/` directory
 2. Activate the plugin through the *Plugins* menu in WordPress
-3. ...and that's it :)
+3. If you wish to define up to three Well-Known URIs that return static output,
+   go to *Settings>Well-Known URIs" and define them, e.g.
+    
+    `Path: /.well-known/`
+        robots.txt
+    
+    `Textual contents:`
+        User-agent: *
+        Allow: /
+4. If you want to configure a Well-Known URI that returns dynamic output,
+   first, edit the plugin source to define a function invoked by
+   `do_action` for the action `"well_known_" + $path`. That function
+    will be invoked when `/.well-known/${path}` is requested.
 
 == Frequently Asked Questions ==
 
 = How can I define a well-known uri? =
 
+Set a callback for an URI (e.g., "/.well-known/robots.txt"),
+identified by `"well_known_" + $path` (e.g., `"well_known_robots.txt"`).
 
-Set a callback for an URI (/.well-known/robots.txt). The action is a combination of `well_known_` and the file-name, in this case the hook must look like
+    `add_action('well_known_robots.txt', 'robots_txt');`
 
-`add_action('well_known_robots.txt', 'robots_txt');`
+In the callback, do whatever processing is appropriate, e.g.,
 
+    `function robots_txt($query) {
+      header('Content-Type: text/plain; charset=' . get_option('blog_charset'), true);
+      echo "User-agent: *";
+      echo "Allow: /";
 
-Print robots.txt:
-
-
-`function robots_txt($query) {
-  header('Content-Type: text/plain; charset=' . get_option('blog_charset'), true);
-  echo "User-agent: *";
-  echo "Allow: /";
-
-  exit;
-}`
+      exit;
+    }`
 
 = Is there an implementation where I can write off? =
 
-Yes, you can find an example plugin, which defines a well-known-uri,
+Yes, you can find an example plugin, which defines a Well-Known URI,
 here: http://wordpress.org/extend/plugins/host-meta/

--- a/readme.txt
+++ b/readme.txt
@@ -63,7 +63,10 @@ page for this plugin.
     `Path: /.well-known/`
         robots.txt
     
-    `Textual contents:`
+    `Content-Type:`
+        text/plain; charset=utf-8
+    
+    `URI contents:`
         User-agent: *
         Allow: /
 4. If you want to configure a Well-Known URI that returns dynamic output,
@@ -83,13 +86,17 @@ identified by `"well_known_" + $path` (e.g., `"well_known_robots.txt"`).
 In the callback, do whatever processing is appropriate, e.g.,
 
     `function robots_txt($query) {
-      header('Content-Type: text/plain; charset=' . get_option('blog_charset'), true);
+      header('Content-Type: text/plain; charset=' . get_option('blog_charset'), TRUE);
       echo "User-agent: *";
       echo "Allow: /";
 
       exit;
     }`
 
+This code defines a URI that returns static output, as shown in Step 3 above.
+(For static output, you will want to use *Settings > Well-Known URIs* page to
+avoid writing any code.)    
+    
 = Is there an implementation where I can write off? =
 
 Yes, you can find an example plugin, which defines a Well-Known URI,

--- a/readme.txt
+++ b/readme.txt
@@ -43,6 +43,9 @@ From the RFC:
     
 You will need 'manage_options' capability in order to use the Settings
 page for this plugin.
+
+NOTE: as with all plugins, once you are no longer using the plugin, you
+should disable it. This is a good security practice.
     
 == Changelog ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -71,7 +71,7 @@ page for this plugin.
         Allow: /
 4. If you want to configure a Well-Known URI that returns dynamic output,
    first, edit the plugin source to define a function invoked by
-   `do_action` for the action `"well_known_" + $path`. That function
+   `do_action` for the action `"well_known_uri_" + $path`. That function
     will be invoked when `/.well-known/${path}` is requested.
 
 == Frequently Asked Questions ==
@@ -79,9 +79,9 @@ page for this plugin.
 = How can I define a well-known uri? =
 
 Set a callback for an URI (e.g., "/.well-known/robots.txt"),
-identified by `"well_known_" + $path` (e.g., `"well_known_robots.txt"`).
+identified by `"well_known_uri_" + $path` (e.g., `"well_known_uri_robots.txt"`).
 
-    `add_action('well_known_robots.txt', 'robots_txt');`
+    `add_action('well_known_uri_robots.txt', 'robots_txt');`
 
 In the callback, do whatever processing is appropriate, e.g.,
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,11 +1,12 @@
-=== /.well-known/ ===
-Contributors: pfefferle
+=== well-known-uris ===
+Contributors: pfefferle, mrose17
 Donate link: http://www.14101978.de
-Tags: well-known, discovery
+Tags: well-known, well-known-uris, discovery
 Requires at least: 3.5.1
 Tested up to: 4.6.1
-Stable tag: 1.0.2
-
+Stable tag: 1.0.3
+License: MPL2
+    
 "Well-Known URIs" for WordPress!
 
 == Description ==
@@ -45,13 +46,11 @@ page for this plugin.
     
 == Changelog ==
 
-= 1.0.2 =
+= 1.0.3 =
 
-* Add Settings page to allow simple configuration of static output URIs
-
-= 0.1 =
-
-* Initial release
+* Fork from the original -- https://wordpress.org/plugins/well-known/ --
+  many thanks to https://profiles.wordpress.org/pfefferle/ for the
+  excellent plugin!
 
 == Installation ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -47,7 +47,7 @@ page for this plugin.
 
 = 1.0.2 =
 
-* Add Settings page to allow simple configuration of upto 3 textual URIs
+* Add Settings page to allow simple configuration of static output URIs
 
 = 0.1 =
 
@@ -57,7 +57,7 @@ page for this plugin.
 
 1. Upload the `well-known`-folder to the `/wp-content/plugins/` directory
 2. Activate the plugin through the *Plugins* menu in WordPress
-3. If you wish to define up to three Well-Known URIs that return static output,
+3. If you wish to define one or more Well-Known URIs that return static output,
    go to *Settings > Well-Known URIs* and define them, e.g.
     
     `Path: /.well-known/`

--- a/readme.txt
+++ b/readme.txt
@@ -58,7 +58,7 @@ page for this plugin.
 1. Upload the `well-known`-folder to the `/wp-content/plugins/` directory
 2. Activate the plugin through the *Plugins* menu in WordPress
 3. If you wish to define up to three Well-Known URIs that return static output,
-   go to *Settings>Well-Known URIs" and define them, e.g.
+   go to *Settings > Well-Known URIs* and define them, e.g.
     
     `Path: /.well-known/`
         robots.txt

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: pfefferle
 Donate link: http://www.14101978.de
 Tags: well-known, discovery
 Requires at least: 3.5.1
-Tested up to: 3.8
-Stable tag: 1.0.1
+Tested up to: 4.6.1
+Stable tag: 1.0.2
 
 "Well-Known URIs" for WordPress!
 
@@ -39,6 +39,10 @@ From the RFC:
 > register their use to avoid collisions and minimise impingement upon
 > sites' URI space.
 
+    
+You will need 'manage_options' capability in order to use the Settings
+page for this plugin.
+    
 == Changelog ==
 
 = 0.6.2 =


### PR DESCRIPTION
for non-programmers, requiring an edit to the plugin source to define the URIs and their contents is probably too much friction. for well-known URIs that have static content, the Setting page is sufficient...

also, tested the plugin on WP latest (4.6.1)

i hope you like this addition, thanks!
